### PR TITLE
Fix ExerciseImporter import path

### DIFF
--- a/database/import_exercises.py
+++ b/database/import_exercises.py
@@ -4,7 +4,7 @@ Script to import exercise data from multiple sources and create a unified databa
 
 import logging
 import os
-from exercise_importer import ExerciseImporter
+from database.exercise_importer import ExerciseImporter
 
 # Configure logging
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- fix import path in `import_exercises.py` so it can be run from repo root

## Testing
- `python -m py_compile database/import_exercises.py`


------
https://chatgpt.com/codex/tasks/task_e_687d7bca62e4832eb3d5ec3960391a69