### PR TITLE
Align ExerciseDB API key naming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,10 +9,7 @@ DATABASE_URL=sqlite:///fitness_plans.db
 # Get your key from https://exercisedb-api.vercel.app/docs for premium features
 EXERCISEDB_API_KEY=your_exercisedb_api_key_here
 
-# API Keys - Replace with your actual keys
-RAPIDAPI_KEY=your_rapidapi_key_here
-
-# API URLs
+# API URL
 EXERCISEDB_API_URL=https://exercisedb.p.rapidapi.com
 
 # Configuration

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ A Streamlit web application that generates personalized fitness plans using AI, 
    - Create a `.env` file in the root directory
    - Add your API keys:
      ```
-     OPENAI_API_KEY=your_openai_api_key
-     RAPIDAPI_KEY=your_rapidapi_key
+    OPENAI_API_KEY=your_openai_api_key
+    EXERCISEDB_API_KEY=your_exercisedb_api_key
      ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- remove unused `RAPIDAPI_KEY` environment variable
- document `EXERCISEDB_API_KEY` consistently in README and `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d7bda29f4832e899a2f7d2d3e41c7