### PR TITLE
Add chat interface and chat API integration

### DIFF
--- a/PTApp.py
+++ b/PTApp.py
@@ -13,6 +13,7 @@ from pages.profile import display_profile_page
 from pages.journal import display_journal_page
 from pages.progress import display_progress_page
 from pages.history import display_history_page
+from pages.chat import display_chat_page
 
 # Configure page and logging
 st.set_page_config(
@@ -69,6 +70,8 @@ if 'current_user' not in st.session_state:
     st.session_state.current_user = None
 if 'shown_popups' not in st.session_state:
     st.session_state.shown_popups = set()
+if 'conversations' not in st.session_state:
+    st.session_state.conversations = {}
 
 # Initialize database
 try:
@@ -174,20 +177,20 @@ def main():
             show_workflow_guidance()
         else:
             # Ensure we have a valid navigation key
-            if st.session_state.nav not in ['home', 'profile', 'journal', 'progress', 'history']:
+            if st.session_state.nav not in ['home', 'profile', 'journal', 'progress', 'history', 'chat']:
                 st.session_state.nav = 'profile'
                 
             # Navigation buttons
             st.markdown('<div style="margin-bottom: 20px;">', unsafe_allow_html=True)
-            cols = st.columns(5)
-            
             nav_items = {
                 'home': ('🏠 Home', display_home_page),
                 'profile': ('👤 Profile', display_profile_page),
                 'journal': ('📓 Journal', display_journal_page),
                 'progress': ('📊 Progress', display_progress_page),
-                'history': ('📚 History', display_history_page)
+                'history': ('📚 History', display_history_page),
+                'chat': ('💬 Chat', display_chat_page)
             }
+            cols = st.columns(len(nav_items))
             
             for i, (nav_key, (label, func)) in enumerate(nav_items.items()):
                 if cols[i].button(label, key=f"nav_{nav_key}", use_container_width=True):
@@ -223,6 +226,8 @@ def main():
                     current_page(st.session_state.current_user)
                 elif current_page == display_history_page:
                     current_page(st.session_state.current_user, plan_service)
+                elif current_page == display_chat_page:
+                    current_page(st.session_state.current_user, plan_service, ai_service)
                 
             except Exception as e:
                 logger.error(f"Error displaying page {st.session_state.nav}: {str(e)}")

--- a/pages/chat.py
+++ b/pages/chat.py
@@ -1,0 +1,41 @@
+import streamlit as st
+from typing import List, Dict
+from services.ai_service_alt import AIService
+from services.plan_service import PlanService
+
+
+def display_chat_page(username: str, plan_service: PlanService, ai_service: AIService):
+    """Display a simple chat interface using Streamlit."""
+    st.subheader("\U0001F4AC Chat")
+
+    # Ensure conversation history exists for this user
+    if "conversations" not in st.session_state:
+        st.session_state.conversations = {}
+    if username not in st.session_state.conversations:
+        st.session_state.conversations[username] = []
+
+    messages: List[Dict[str, str]] = st.session_state.conversations[username]
+
+    # Show previous messages
+    for msg in messages:
+        with st.chat_message(msg["role"]):
+            st.markdown(msg["content"])
+
+    # Input box for the next user message
+    prompt = st.chat_input("Type your message")
+    if prompt:
+        messages.append({"role": "user", "content": prompt})
+
+        # Build context from latest plan and journal summary
+        journal_summary = plan_service.get_journal_summary(username)
+        latest_plan = plan_service.get_latest_plan(username)
+        plan_text = latest_plan.plan if latest_plan else "No plan available."
+        context = f"Latest Plan:\n{plan_text}\n\nRecent Journal Summary:\n{journal_summary}"
+
+        try:
+            reply = ai_service.chat_with_user(messages, context)
+            messages.append({"role": "assistant", "content": reply})
+        except Exception as e:
+            st.error(f"Chat error: {e}")
+
+        st.rerun()

--- a/services/ai_service_alt.py
+++ b/services/ai_service_alt.py
@@ -643,3 +643,15 @@ DO NOT include any other sections. ONLY provide the progress tracking guide.
                 formatted_data.append(f"Favorite Foods: {value}")
         
         return "\n".join(formatted_data)
+
+    def chat_with_user(self, messages: List[Dict[str, str]], context: str) -> str:
+        """Send a chat conversation to the OpenAI API and return the assistant reply."""
+        payload = {
+            "model": "gpt-4-turbo",
+            "messages": [{"role": "system", "content": context}] + messages,
+            "temperature": 0.7,
+            "max_tokens": 1000,
+        }
+
+        response = self._call_openai_api("chat/completions", payload)
+        return response["choices"][0]["message"]["content"]


### PR DESCRIPTION
## Summary
- create `pages/chat.py` with a simple Streamlit chat interface
- add `chat_with_user` to `AIService` for OpenAI chat API
- track conversation history in session state
- expose new Chat page in navigation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d80d1baa0832eb1c205c66e44a4e6